### PR TITLE
fix(client): wire the effort memory from session birth and retry refused restores / 让思考强度自会话诞生即生效并重试失败恢复

### DIFF
--- a/src/client/effort-memory.ts
+++ b/src/client/effort-memory.ts
@@ -24,10 +24,10 @@
  *     every surface shows the re-applied level;
  *   - the projection watcher: a RESTORED session's durable selection arrives
  *     from session history without going through `select` at all, so the
- *     watcher re-applies the chain to a level-less projection (one best-
- *     effort attempt per model per directory lifetime — spent attempts are
- *     never retried, which also keeps an explicit provider-default pick
- *     from being fought).
+ *     watcher re-applies the chain to a level-less projection (one successful
+ *     attempt per model per directory lifetime; a REFUSED attempt is refunded
+ *     and retried on the next store update, up to a small ceiling — which
+ *     also keeps an explicit provider-default pick from being fought).
  * Discipline both paths keep:
  *   - an EXPLICIT level (slider drag, any effort row) always wins: it is
  *     remembered for that exact model and submitted untouched;
@@ -199,11 +199,17 @@ export function wireEffortMemory(directory: ModelDirectoryLike): () => void {
   // onto the instance (which would keep shadowing a hot-swapped prototype).
   const hadOwnSelect = Object.prototype.hasOwnProperty.call(target, 'select')
   const original = directory.select
-  // One restore attempt per model per directory lifetime: spent attempts are
-  // never retried, which bounds the watcher (no loop on a refused write) and
-  // keeps an explicit provider-default pick from being fought. Bounded by the
-  // number of models a session touches; dies with the directory.
+  // One successful restore per model per directory lifetime: spent attempts
+  // are never retried, which bounds the watcher (no loop on a refused write)
+  // and keeps an explicit provider-default pick from being fought. A REFUSED
+  // submission refunds its attempt -- a brand-new session's host may refuse
+  // the first selectModel while the session is still initializing -- up to a
+  // small ceiling, beyond which the model is given up on for this directory.
   const attemptedRestores = new Set<string>()
+  const restoreFailures = new Map<string, number>()
+
+  /** Stop retrying one model after this many refused restores (per directory). */
+  const RESTORE_RETRY_LIMIT = 3
 
   const wrapped = async (
     selection: Parameters<ModelDirectoryLike['select']>[0],
@@ -238,14 +244,28 @@ export function wireEffortMemory(directory: ModelDirectoryLike): () => void {
     if (!sliderEnabled()) return
     const key = memoryKey(current.provider, current.model)
     if (attemptedRestores.has(key)) return
-    attemptedRestores.add(key)
     const fallback = resolveFallback(snapshot, current.provider, current.model)
-    if (fallback === undefined) return
+    if (fallback === undefined) {
+      // A deterministic miss (no advertised ladder, or no landing level on it)
+      // will not answer differently later: spend the attempt so the watcher
+      // does not re-resolve the same dead end on every store update.
+      attemptedRestores.add(key)
+      return
+    }
+    attemptedRestores.add(key)
     // Directly through the ORIGINAL select: the watcher's own re-apply is a
     // memory READ, not a user pick, and must not be remembered as one.
     void original
       .call(directory, { provider: current.provider, model: current.model, reasoningEffort: fallback })
-      .catch(() => undefined)
+      .catch(() => {
+        // A refusal is transient (a session mid-initialization), not a
+        // decision: refund the attempt so the next store update retries --
+        // but stop at the ceiling so a persistently rejected submission
+        // cannot turn the watcher into a loop.
+        const failures = (restoreFailures.get(key) ?? 0) + 1
+        restoreFailures.set(key, failures)
+        if (failures < RESTORE_RETRY_LIMIT) attemptedRestores.delete(key)
+      })
   }
 
   const unsubscribe = directory.store.subscribe(restoreProjection)

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -256,8 +256,18 @@ export function apply(ctx: ClientContext): void {
   // `select` kept for the fiber disposer to restore.
   const wiredDirectories = new Map<ModelDirectoryLike, () => void>()
 
-  /** Resolve the current session's model directory (lazy seat probe). */
-  const currentDirectory = (): ModelDirectoryLike | undefined => {
+  /**
+   * Resolve the current session's model directory and wire the effort-memory
+   * wiretap into it. Deliberately menu-INDEPENDENT: the directory is a
+   * per-session instance, and a brand-new session's durable projection lands
+   * without going through `select`, so the watcher is the only thing that can
+   * re-apply the remembered level to it — it must be in place from the
+   * session's birth, not from the first time the user opens the model menu
+   * (issue #4: every new session otherwise read as Default until a manual
+   * pick). Runs on every mutation and scan; the per-session cache makes the
+   * hot path one snapshot read.
+   */
+  const ensureSessionDirectory = (): ModelDirectoryLike | undefined => {
     const host = ctx as unknown as SliderContext
     const sessions = host.get?.('sessions') as SessionsLike | undefined
     const directories = host.get?.('modelDirectories') as ModelDirectoriesLike | undefined
@@ -300,7 +310,7 @@ export function apply(ctx: ClientContext): void {
       }
       return
     }
-    const directory = currentDirectory()
+    const directory = ensureSessionDirectory()
     if (directory === undefined) {
       // Transient boot window only: the seat itself cannot mount before the
       // directory service resolves, so a menu open here is momentary. The
@@ -380,6 +390,10 @@ export function apply(ctx: ClientContext): void {
     // applying); one scan per frame keeps the editor stable mid-keystroke.
     scanTimer = window.setTimeout(() => {
       scanTimer = undefined
+      // Menu-independent effort-memory wiring (issue #4): the debounced scan
+      // also covers the paths no mutation carries — apply boot and a slider
+      // preference flip.
+      ensureSessionDirectory()
       const root = panelRoot()
       reconcile(root, {
         api: settingsApi,
@@ -427,6 +441,9 @@ export function apply(ctx: ClientContext): void {
 
   const startObserver = (): void => {
     if (observer !== undefined) return
+    // A session may already be resident when the fiber starts (page reload,
+    // HMR): wire it before the first mutation has a chance to land.
+    ensureSessionDirectory()
     observer = new MutationObserver(() => {
       // The slider path runs SYNCHRONOUSLY on the mutation microtask: the
       // React commit that opens the menu and this callback are delivered
@@ -434,6 +451,10 @@ export function apply(ctx: ClientContext): void {
       // carries the replicated popover — the official menu never flashes and
       // is never "covered". The settings-page editor/toggle reconciles stay
       // debounced below (they do heavy wire reads).
+      // The effort-memory wiring leads the callback for the same reason: a
+      // session switch lands as a DOM mutation, and the new session's
+      // directory must be watched before its projection can read as Default.
+      ensureSessionDirectory()
       reconcileSlider()
       scheduleScan()
     })

--- a/tests/client.spec.tsx
+++ b/tests/client.spec.tsx
@@ -564,6 +564,60 @@ describe('client apply()', () => {
     }
   })
 
+  it('wires the effort-memory wiretap without the model menu ever opening', async () => {
+    const directory = directoryFixture()
+    // The wrapped select is a plain closure; the spy shape lives on the
+    // original it captured — calls made through the wrapper land here.
+    const originalSelect = directory.select as unknown as { mock: { calls: unknown[][] } }
+    const api = fakeApi(() => Promise.resolve(makeJoin(structuredClone(JOIN_FIXTURE))))
+    const h = makeCtx(api, {
+      services: {
+        sessions: { list: { getSnapshot: () => ({ current: 's1' }) } },
+        modelDirectories: { directoryFor: () => directory },
+      },
+    })
+    try {
+      // No composer card and no model menu in the DOM at all: the wiring must
+      // not depend on the menu popover existing (issue #4 — a brand-new
+      // session's projection lands without going through select, so the
+      // restore watcher has to be in place from the session's birth, not
+      // from the first time the user opens the model menu).
+      const { apply } = await import('../src/client/index.js')
+      apply(h.ctx as unknown as Ctx)
+      expect(directory.select).not.toBe(originalSelect)
+      // The watcher reacts to a level-less projection landing after wiring.
+      directory.update({
+        current: { provider: 'aliyun', model: 'qwen-max' },
+        routable: true,
+        groups: [{
+          id: 'aliyun',
+          name: 'Aliyun',
+          models: [{
+            id: 'qwen-max',
+            name: 'Qwen Max',
+            reasoning: {
+              defaultEffort: 'medium',
+              efforts: [{ id: 'off', name: 'Off' }, { id: 'low', name: 'Low' }, { id: 'medium', name: 'Medium' }, { id: 'high', name: 'High' }, { id: 'max', name: 'Max' }],
+            },
+          }],
+        }],
+        failures: [],
+        status: 'ready',
+        error: null,
+      })
+      await waitFor(() => originalSelect.mock.calls.length > 0)
+      // No memory and no provider-native sighting: the restore lands the
+      // knowledge base's vendor default for the family (qwen-max → high),
+      // NOT the fixture's adapter defaultEffort — the chain never reads it.
+      expect(originalSelect.mock.calls[0][0])
+        .toMatchObject({ provider: 'aliyun', model: 'qwen-max', reasoningEffort: 'high' })
+    } finally {
+      h.disposeAll()
+      // Fiber disposal restores the directory's original select.
+      expect(directory.select).toBe(originalSelect)
+    }
+  })
+
   it('re-inserts the slider when a React re-render displaces it', async () => {
     const directory = directoryFixture()
     const api = fakeApi(() => Promise.resolve(makeJoin(structuredClone(JOIN_FIXTURE))))

--- a/tests/effort-memory.spec.tsx
+++ b/tests/effort-memory.spec.tsx
@@ -7,7 +7,7 @@
  */
 
 // @vitest-environment jsdom
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   rememberEffort,
   rememberedEffort,
@@ -80,13 +80,20 @@ type Selection = Parameters<ModelDirectoryLike['select']>[0]
 /** A directory fake whose submissions are recorded; `state` is swappable. */
 function fakeDirectory(
   initial: ModelDirectoryStateLike,
-  opts?: { rejectSelects?: boolean },
+  opts?: {
+    rejectSelects?: boolean
+    /** Reject the first N submissions (a session mid-initialization), then accept. */
+    rejectFirst?: number
+  },
 ): {
   directory: ModelDirectoryLike
   submitted: Selection[]
+  /** How many times `select` was invoked, refusals included. */
+  attempts: () => number
   update(next: ModelDirectoryStateLike): void
 } {
   let state = initial
+  let selectCalls = 0
   const submitted: Selection[] = []
   const listeners = new Set<() => void>()
   const directory = {
@@ -100,9 +107,11 @@ function fakeDirectory(
     load: async (): Promise<ModelDirectoryStateLike> => state,
     select: async (selection: Selection): Promise<unknown> => {
       // The real directory throws on a rejected selection (directory.ts).
-      if (opts?.rejectSelects === true) {
+      if (opts?.rejectSelects === true || selectCalls < (opts?.rejectFirst ?? 0)) {
+        selectCalls += 1
         throw new Error('session.selectModel failed: session/invalid: no such effort')
       }
+      selectCalls += 1
       submitted.push(selection)
       return undefined
     },
@@ -110,6 +119,7 @@ function fakeDirectory(
   return {
     directory: directory as unknown as ModelDirectoryLike,
     submitted,
+    attempts: () => selectCalls,
     update(next: ModelDirectoryStateLike): void {
       state = next
       for (const listener of [...listeners]) listener()
@@ -323,6 +333,62 @@ describe('wireEffortMemory: restored projections', () => {
       expect(gated.submitted).toHaveLength(0)
     } finally {
       restoreGated()
+    }
+  })
+
+  it('retries refused restores across store updates until the memory lands', async () => {
+    rememberEffort('moonshot', 'kimi-k3', 'low')
+    const fake = fakeDirectory(
+      stateWith({ provider: 'moonshot', model: 'kimi-k3' }, { restore: true }),
+      { rejectFirst: 2 },
+    )
+    const restore = wireEffortMemory(fake.directory)
+    try {
+      // The wire-time attempt is refused (a session mid-initialization) and
+      // must NOT spend the model's restore: the refusal is refunded.
+      await vi.waitFor(() => expect(fake.attempts()).toBe(1))
+      expect(fake.submitted).toEqual([])
+      // Each later store update retries the refunded attempt (the real
+      // directory surfaces a refusal through the store, and any projection /
+      // catalog movement re-notifies the watcher), until one lands the
+      // remembered level.
+      fake.update(stateWith({ provider: 'moonshot', model: 'kimi-k3' }, { restore: true }))
+      await vi.waitFor(() => expect(fake.attempts()).toBe(2))
+      fake.update(stateWith({ provider: 'moonshot', model: 'kimi-k3' }, { restore: true }))
+      await vi.waitFor(() => expect(fake.submitted).toEqual([
+        { provider: 'moonshot', model: 'kimi-k3', reasoningEffort: 'low' },
+      ]))
+      // The successful attempt is final: later updates stay quiet.
+      fake.update(stateWith({ provider: 'moonshot', model: 'kimi-k3' }, { restore: true }))
+      await new Promise(resolve => setTimeout(resolve, 0))
+      expect(fake.attempts()).toBe(3)
+    } finally {
+      restore()
+    }
+  })
+
+  it('gives up on one model after the retry ceiling and stays quiet', async () => {
+    rememberEffort('moonshot', 'kimi-k3', 'low')
+    const fake = fakeDirectory(
+      stateWith({ provider: 'moonshot', model: 'kimi-k3' }, { restore: true }),
+      { rejectSelects: true },
+    )
+    const restore = wireEffortMemory(fake.directory)
+    try {
+      // Exactly the ceiling's worth of attempts — the wire-time attempt plus
+      // one refund per later store update — then the watcher stands down for
+      // this directory instead of retrying forever.
+      await vi.waitFor(() => expect(fake.attempts()).toBe(1))
+      fake.update(stateWith({ provider: 'moonshot', model: 'kimi-k3' }, { restore: true }))
+      await vi.waitFor(() => expect(fake.attempts()).toBe(2))
+      fake.update(stateWith({ provider: 'moonshot', model: 'kimi-k3' }, { restore: true }))
+      await vi.waitFor(() => expect(fake.attempts()).toBe(3))
+      // The ceiling is reached: later updates attempt nothing more.
+      fake.update(stateWith({ provider: 'moonshot', model: 'kimi-k3' }, { restore: true }))
+      await new Promise(resolve => setTimeout(resolve, 0))
+      expect(fake.attempts()).toBe(3)
+    } finally {
+      restore()
     }
   })
 })


### PR DESCRIPTION
## 概述 / Summary

加固思考强度持久化策略的两个漏洞，使"记住上次使用的思考强度"在新会话与初始化窗口期也能生效。**本 PR 不关闭 #4**——issue 中用户要求的"默认思考强度"设置项将在后续 PR 单独实现（`Partially addresses #4`）。

This PR hardens two holes in the effort-memory persistence so the remembered level also applies on brand-new sessions and across the session-initialization window. **It deliberately does NOT close #4** — the "default effort" setting requested in the issue lands in a follow-up PR.

## 问题 / Problem

用户报告每个新会话的思考强度都回到 Default，需要手动指定（#4）。

A user reported every new session starting at Default, requiring a manual pick each time (#4).

审查确认这不是误解，持久化策略存在两个确定性漏洞：

The review confirmed the report; the persistence strategy has two real holes:

1. **接线时机绑定在模型菜单上**：effort-memory 的 wiretap（包裹 `select` + 恢复监听）只在官方模型菜单 popover 打开时安装，而 model directory 是每会话新实例。新会话的持久化投影不经过 `select` 落位（`projected.next ?? catalog.default`，不带档位），只要用户不开菜单，监听器就不存在，记忆档位无人读取——请求以 Default 发出。用户"手动指定"的动作（打开菜单）恰好是触发安装的动作，补档发生在发消息之后。
2. **恢复尝试失败即烧毁**：投影恢复的 re-apply 在提交前就消耗尝试额度，失败被静默吞掉。会话初始化窗口期 host 拒绝一次 `selectModel`，该模型在整个 directory 生命周期内不再重试。

1. **Wiring bound to the model menu**: the effort-memory wiretap (the wrapped `select` plus the restore watcher) was only installed when the official model-menu popover existed in the DOM, and model directories are per-session instances. A new session's durable projection lands WITHOUT going through `select` (`projected.next ?? catalog.default`, carrying no level), so with the menu never opened there was no watcher to read the memory — the request went out at Default. The very act of picking manually (opening the menu) is what installed the wiretap, re-applying only after the message had already been sent.
2. **A failed restore burned its one attempt**: the projection watcher spent the attempt before submitting and swallowed failures silently, so one refused `selectModel` during the session-initialization window left that model on Default for the whole directory lifetime.

## 修复 / Fix

- **接线与菜单解耦**（62381c3）：把目录解析与安装提为独立的 `ensureSessionDirectory()`，由 MutationObserver 回调、启动路径与去抖扫描三处驱动（有 per-session 缓存，热路径只多一次快照读），监听器从会话诞生起就在位。
- **失败回收 + 有界重试**（d9105b6）：拒绝时回收尝试额度，后续 store 更新重试；每个模型每个 directory 最多 3 次拒绝后放弃（防紧循环）。确定性落空（无梯级可落）仍一次性烧掉，不空转。

- **Menu-independent wiring** (62381c3): directory resolution + wiring becomes a standalone `ensureSessionDirectory()` driven from the mutation callback, the boot path and the debounced scan (per-session cached; the hot path costs one extra snapshot read). The watcher is in place from the session's birth.
- **Refund + bounded retry** (d9105b6): a refused restore refunds its attempt and retries on the next store update, giving up after 3 refused restores per model per directory (no tight loop). A deterministic miss (no landing level on the ladder) still spends the attempt outright.

## 测试 / Testing

- 新增 4 个用例：菜单从不打开也安装 wiretap（并钉住无记忆时落到知识库 vendor default 的 fallback 行为）、拒绝后跨 store 更新重试直至落地、重试上限后收手。
- 全量回归 301/301 通过（18 个文件），`tsc --noEmit` 通过。

- 4 new tests: the wiretap installs with the menu never opened (pinning the vendor-default fallback when no memory exists), refused restores retried across store updates until they land, and stand-down after the retry ceiling.
- Full suite 301/301 (18 files); `tsc --noEmit` clean.

Refs #4
